### PR TITLE
Use URLSession to load images in the background + linting fixes

### DIFF
--- a/AC Widget/API/AppStoreConnectApi.swift
+++ b/AC Widget/API/AppStoreConnectApi.swift
@@ -278,7 +278,7 @@ class AppStoreConnectApi {
             throw APIError.unknown
         }
 
-        if let data = try? Data(contentsOf: url) {
+        if let data = try? await URLSession.shared.data(from: url).0 {
             let decoder = JSONDecoder()
             let result = try? decoder.decode(ITunesResponse.self, from: data)
             guard let appData = result?.results.first else {
@@ -287,7 +287,7 @@ class AppStoreConnectApi {
 
             var imageData: Data?
             if let imgUrl = URL(string: appData.artworkUrl60) {
-                imageData = try? Data(contentsOf: imgUrl)
+                imageData = try? await URLSession.shared.data(from: imgUrl).0
             }
 
             return ACApp(appstoreId: app.appstoreId,

--- a/AC Widget/API/CurrencyConverter.swift
+++ b/AC Widget/API/CurrencyConverter.swift
@@ -165,7 +165,7 @@ private class CurrencyXMLParser: NSObject, XMLParserDelegate {
         return exchangeRates
     }
 
-    public func parse(completion : @escaping () -> Void, errorCompletion : @escaping () -> Void) {
+    public func parse(completion: @escaping () -> Void, errorCompletion: @escaping () -> Void) {
         guard let url = URL(string: xmlURL) else { return }
         let task = URLSession.shared.dataTask(with: url) { data, _, error in
             guard let data = data, error == nil else {


### PR DESCRIPTION
Hi @cameronshemilt & @mikakruschel ,
I am quite excited about the widget and have been using it since it was released 🚀 
Currently I am having problems with the widget from time to time and am trying to debug it. I have seen that Xcode writes warnings that image data is loaded on the main thread. I fixed this with the async/await call to URLSession. I'm still looking at the widget issue when I get it working. Currently it's a bit difficult unfortunately as I need to set up all the BundleId, AppGroup, Keychain identifiers for my dev account. If there is interest, you can of course invite me as a developer to your dev account.
Best regards
Julian 🙂 